### PR TITLE
Dockerfile: add koji python module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 from registry.fedoraproject.org/fedora:33
 
 run dnf -y update fedora-gpg-keys && \
-    dnf -y install python3-jinja2 python3-yaml git && \
+    dnf -y install git python3-jinja2 python3-koji python3-yaml && \
     dnf clean all 
     
 workdir /workspace


### PR DESCRIPTION
Commit b571f173 adds a koji dependency to feedback_pipeline.py. The
Dockerfile didn't add this dependency in parallel so this commit does
that.