### PR TITLE
Fix root.log trigger line

### DIFF
--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -2729,7 +2729,7 @@ class Analyzer():
 
                 # The next installation is the build deps!
                 # So I start caring. Next state!
-                if "Executing command: ['/usr/bin/systemd-nspawn'" in file_line:
+                if "'/usr/bin/dnf', 'builddep'" in file_line:
                     state += 1
             
 

--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -2729,7 +2729,7 @@ class Analyzer():
 
                 # The next installation is the build deps!
                 # So I start caring. Next state!
-                if "Executing command: ['/usr/bin/dnf', 'builddep'" in file_line:
+                if "Executing command: ['/usr/bin/systemd-nspawn'" in file_line:
                     state += 1
             
 

--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -2763,10 +2763,10 @@ class Analyzer():
             elif state == 3:
 
                 if "Installing dependencies:" in file_line:
-                    state += 1
+                    state = 2
 
                 elif "Transaction Summary" in file_line:
-                    state += 1
+                    state = 2
                     
                 else:
                     # I need to deal with the following thing...


### PR DESCRIPTION
Mock in Koji changed a few months ago.  As a result, key parts of the root.log changed.
This fixes the parser so that it can determine when the next section has started.

Signed-off-by: Troy Dawson <tdawson@redhat.com>