### PR TITLE
Add strictness option for config import

### DIFF
--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -971,6 +971,8 @@ def get_configs(settings):
             log("  |  {}".format(message))
         log("  -------------------------------------------------------------------------")
         log("")
+        if settings.get("strict", False):
+            raise ConfigError("Config file errors encountered in strict mode")
     else:
         log("")
         log("  ✅ No serious errors found.")
@@ -986,7 +988,7 @@ def get_configs(settings):
     log("---------------------")
     log("")
     for json_file in os.listdir(directory):
-        # Only accept yaml files
+        # Only accept json files
         if not json_file.endswith(".json"):
             continue
         
@@ -1023,6 +1025,8 @@ def get_configs(settings):
             log("  |  {}".format(message))
         log("  -------------------------------------------------------------------------")
         log("")
+        if settings.get("strict", False):
+            raise ConfigError("Config file errors encountered in strict mode")
     else:
         log("")
         log("  ✅ No serious errors found.")

--- a/test_config_files.py
+++ b/test_config_files.py
@@ -5,6 +5,7 @@ import feedback_pipeline
 def create_mock_settings():
     settings = {}
     settings["configs"] = "input/configs"
+    settings["strict"] = True
     settings["allowed_arches"] = ["armv7hl","aarch64","ppc64le","s390x","x86_64"]
 
     return settings


### PR DESCRIPTION
This will allow us to use the test_config_files.py for pull request tests in the content-resolver-input repository.