### PR TITLE
Update trigger line for builddeps

### DIFF
--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -2818,7 +2818,7 @@ class Analyzer():
 
                 # The next installation is the build deps!
                 # So I start caring. Next state!
-                if "'/usr/bin/dnf', 'builddep'" in file_line:
+                if "'builddep', '--installroot'" in file_line:
                     state += 1
             
 


### PR DESCRIPTION
As part of the transition to dnf5, the builddep line has temporarily changed to `/usr/bin/dnf-3`. It's likely to change again in the near future, so triggering off of `builddep, installroot` should be safer.