### PR TITLE
Update links to input repository

### DIFF
--- a/templates/config_env.html
+++ b/templates/config_env.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{env_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{env_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_label.html
+++ b/templates/config_label.html
@@ -21,7 +21,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{label_conf.id}}.yaml"
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{label_conf.id}}.yaml"
                 class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>

--- a/templates/config_repo.html
+++ b/templates/config_repo.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{repo_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_unwanted.html
+++ b/templates/config_unwanted.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{unwanted_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{unwanted_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_view.html
+++ b/templates/config_view.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{view_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{view_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_workload.html
+++ b/templates/config_workload.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{workload_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{workload_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/repo-split.html
+++ b/templates/repo-split.html
@@ -120,7 +120,7 @@
                             <ul>
                             {% for repo_split_conf_id in repo_split_conf_ids %}
                             <li>
-                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
+                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
                             </li>
                             {% endfor %}
                             </ul>
@@ -135,7 +135,7 @@
                             <ul>
                             {% for repo_split_conf_id in repo_split_conf_ids %}
                             <li>
-                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/feedback-pipeline-config/blob/master/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
+                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
                             </li>
                             {% endfor %}
                             </ul>


### PR DESCRIPTION
Use the current URLs for the resolver input to avoid unnecessary redirects due to an outdated project name and outdated git branch name.