### PR TITLE
Do not inherit repositories in addons

### DIFF
--- a/feedback_pipeline.py
+++ b/feedback_pipeline.py
@@ -685,6 +685,7 @@ def _load_config_addon_view(document_id, document, settings):
 
         # Choose one repository that gets used as a source.
         config["base_view_id"] = str(document["data"]["base_view_id"])
+        config["repository"] = str(document["data"]["repository"])
 
     except KeyError:
         raise ConfigError("'{file}.yaml' - There's something wrong with the mandatory fields. Sorry I don't have more specific info.".format(file=document_id))
@@ -1131,7 +1132,6 @@ def get_configs(settings):
 
             
             # Ading some extra fields onto the addon view
-            configs["views"][view_conf_id]["repository"] = configs["views"][base_view_id]["repository"]
             configs["views"][view_conf_id]["architectures"] = configs["views"][base_view_id]["architectures"]
     
     # Adjust view architecture based on repository architectures

--- a/test_configs/repo-eln-extras.yaml
+++ b/test_configs/repo-eln-extras.yaml
@@ -2,8 +2,8 @@
 document: feedback-pipeline-repository
 version: 2
 data:
-  name: Fedora ELN (backed by rawhide)
-  description: Fedora ELN with rawhide as a backup for missing packages
+  name: Fedora ELN Extras (backed by rawhide)
+  description: Fedora ELN Extras, based on ELN with rawhide as a backup for missing packages
   maintainer: asamalik
   source:
 
@@ -78,6 +78,12 @@ data:
         limit_arches: ["ppc64le", "x86_64"]
         priority: 2
 
+      Extras:
+        baseurl: https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/$basearch/os/
+        koji_api_url: https://koji.fedoraproject.org/kojihub
+        koji_files_url: https://kojipkgs.fedoraproject.org
+        exclude: ["exim", "esmtp", "opensmtpd", "esmtp-local-delivery"]
+        priority: 3
       
       Rawhide:
         baseurl: https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Everything/$basearch/os/

--- a/test_configs/view-eln-extras.yaml
+++ b/test_configs/view-eln-extras.yaml
@@ -35,6 +35,11 @@ data:
   # (mandatory field)
   base_view_id: view-eln
 
+  # ID of the repositories where this addon and its base are shipped.
+  #
+  # (mandatory field)
+  repository: repo-eln-extras
+
   # Labels connect things together.
   # Workloads get installed in environments with the same label.
   # They also get included in views with the same label.


### PR DESCRIPTION
An addon repository does not necessarily want the same repos or exclusions as its base, and vice versa.  For example, ELN should really not include Extras, and a lot of unwanted packages that we want to filter from Buildroot or Rawhide may still be eligible for ELN Extras.
