### PR TITLE
Make `Package "..." is already installed` handling more robust

### DIFF
--- a/test_root_log_function.py
+++ b/test_root_log_function.py
@@ -1,10 +1,16 @@
+#! /usr/bin/python3
+
 from feedback_pipeline import Analyzer
+import sys
 import urllib
 
 # This is a starting point for a test of the function parsing root logs.
 # Set the url below to any root log, and then you can see what it detected.
 
-root_log_url = "https://kojipkgs.fedoraproject.org//packages/gstreamer1-vaapi/1.22.9/1.fc39/data/logs/x86_64/root.log"
+if len(sys.argv) > 1:
+    root_log_url = sys.argv[1]
+else:
+    root_log_url = "https://kojipkgs.fedoraproject.org//packages/gstreamer1-vaapi/1.22.9/1.fc39/data/logs/x86_64/root.log"
 
 with urllib.request.urlopen(root_log_url) as response:
     root_log_data = response.read()


### PR DESCRIPTION
DNF5 sometimes prints `Package "..." is already installed.` in the middle of the list of packages to be installed.  This is possibly a race condition in dnf5 itself that should be fixed, but in the meantime, this should handle the cases that have been seen so far.

Also, allow testing against an arbitrary root.log provided on the command line.

Currently available test cases:

https://kojipkgs.fedoraproject.org//packages/ipa/4.12.1/1.eln142.1/data/logs/s390x/root.log
https://kojipkgs.fedoraproject.org//packages/acl/2.3.2/2.eln142/data/logs/ppc64le/root.log
https://kojipkgs.fedoraproject.org//packages/flatpak-builder/1.4.4/2.eln142/data/logs/s390x/root.log
https://kojipkgs.fedoraproject.org//packages/ktls-utils/0.11/2.eln142/data/logs/ppc64le/root.log
https://kojipkgs.fedoraproject.org//packages/subscription-manager/1.29.41/1.eln142/data/logs/s390x/root.log
https://kojipkgs.fedoraproject.org//packages/time/1.9/24.eln142/data/logs/x86_64/root.log