### PR TITLE
updated fedora version to 41 and added python3-dnf

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ jobs:
   setup_and_test:
     runs-on: ubuntu-latest
     container: 
-      image: registry.fedoraproject.org/fedora:40
+      image: registry.fedoraproject.org/fedora:41
     steps:
     
     - name: Checkout code
@@ -18,7 +18,7 @@ jobs:
       run: dnf -y update fedora-gpg-keys
         
     - name: Install git and Python libraries
-      run: dnf -y install git-core python3-yaml python3-jinja2 python3-koji python3-pytest python3-flake8
+      run: dnf -y install git-core python3-yaml python3-jinja2 python3-koji python3-pytest python3-flake8 python3-dnf
     
     - name: Clean up
       run: dnf clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-from registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:41
 
-run dnf -y update fedora-gpg-keys && \
-    dnf -y install git python3-jinja2 python3-koji python3-yaml && \
-    dnf clean all 
-    
-workdir /workspace
+RUN dnf -y update fedora-gpg-keys && \
+    dnf -y install git python3-jinja2 python3-koji python3-yaml python3-dnf && \
+    dnf clean all
+
+WORKDIR /workspace
 


### PR DESCRIPTION
For #75 

Fedora 41 also updates the python version to 3.13.

In Fedora 41, dnf is provided by dnf5. With this update we must now install python3-dnf as it is no longer installed by default.