### PR TITLE
Update URLs for move to github.com/fedora-eln

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Content Resolver also helps with minimisation efforts by showing detailed depend
 
 Content Resolver is entirely controlled by a set of YAML files stored in a git repository. Changes to the content can easily be modified and reviewed via pull requests.
 
-[See Fedora's input repository](https://github.com/minimization/content-resolver-input)
+[See Fedora ELN's input repository](https://github.com/fedora-eln/content-resolver-input)
 
 ### Main concepts
 
@@ -64,7 +64,7 @@ Build dependencies are currently resolved in an external service (dep-tracker) b
 
 Current limitations: Because the build dependencies are resolved by an external service, the results might lag as much as several hours behind the runtime views. There is also currently no distinction between direct build dependencies and dependencies of build dependencies in on the package details page.
 
-There's [work being done (#27)](https://github.com/minimization/content-resolver/issues/27) to change the way build dependencies are resolved (using data from Koji rather than the SRPMs themselves) that will remove the current limitations.
+There's [work being done (#27)](https://github.com/fedora-eln/content-resolver/issues/27) to change the way build dependencies are resolved (using data from Koji rather than the SRPMs themselves) that will remove the current limitations.
 
 ### Reasons of Presence
 
@@ -80,7 +80,7 @@ Maintainers can flag certain packages as unwanted. That causes these packages to
 
 In combination with Reasons of Presence, this helps maintainers identify what dependencies need to be cut in order to remove the unwanted packages.
 
-Current limitations: There's currently only a single level of unwanted packages. But there's [work being done (#28)](https://github.com/minimization/content-resolver/issues/28) to allow additional levels, such as a distinction between "unwanted in the runtime set" vs. "unwanted in buildroot as well".
+Current limitations: There's currently only a single level of unwanted packages. But there's [work being done (#28)](https://github.com/fedora-eln/content-resolver/issues/28) to allow additional levels, such as a distinction between "unwanted in the runtime set" vs. "unwanted in buildroot as well".
 
 ### Maintainer recommendation
 
@@ -88,7 +88,7 @@ Because views are defined by multiple parties, it's not always clear who should 
 
 That's why Content Resolver helps identify who pulls each package into the set "the most" and recommends ownership based on that.
 
-Current limitations: Content Resolver doesn't look at anything else, just the dependencies and who pulled it in. But parties can volunteer to own a package. In that case, Content Resolver should be able to see that and show that instead. There's [work being done (#29)](https://github.com/minimization/content-resolver/issues/29) that will allow maintainers to accept a package, allowing Content Resolver to use this information when recommending owners.
+Current limitations: Content Resolver doesn't look at anything else, just the dependencies and who pulled it in. But parties can volunteer to own a package. In that case, Content Resolver should be able to see that and show that instead. There's [work being done (#29)](https://github.com/fedora-eln/content-resolver/issues/29) that will allow maintainers to accept a package, allowing Content Resolver to use this information when recommending owners.
 
 ## Running Content Resolver
 

--- a/eln_repo_split_prototype.py
+++ b/eln_repo_split_prototype.py
@@ -221,7 +221,7 @@ def main():
     wishes_hardcoded = {
 
         # I found these in this in an old file here:
-        # https://github.com/minimization/content-resolver-input/blob/main/configs/eln-repo-split.yaml
+        # https://github.com/fedora-eln/content-resolver-input/blob/main/configs/eln-repo-split.yaml
         # It's a start!
         "BaseOS": [
             "attr",

--- a/refresh-cs.sh
+++ b/refresh-cs.sh
@@ -22,9 +22,9 @@ trap cleanup EXIT
 cd $WORK_DIR
 
 # Get the latest code repo and configs
-git clone https://github.com/minimization/content-resolver || exit 1
+git clone https://github.com/fedora-eln/content-resolver || exit 1
 cd content-resolver || exit 1
-git clone https://github.com/minimization/content-resolver-input || exit 1
+git clone https://github.com/fedora-eln/content-resolver-input || exit 1
 
 # Local output dir. Includes a dir for the history data, too.
 mkdir -p $WORK_DIR/content-resolver/out/history || exit 1

--- a/refresh.sh
+++ b/refresh.sh
@@ -22,9 +22,9 @@ trap cleanup EXIT
 cd $WORK_DIR
 
 # Get the latest code repo and configs
-git clone https://github.com/minimization/content-resolver || exit 1
+git clone https://github.com/fedora-eln/content-resolver || exit 1
 cd content-resolver || exit 1
-git clone https://github.com/minimization/content-resolver-input || exit 1
+git clone https://github.com/fedora-eln/content-resolver-input || exit 1
 
 # Local output dir. Includes a dir for the history data, too.
 mkdir -p $WORK_DIR/content-resolver/out/history || exit 1

--- a/templates/config_env.html
+++ b/templates/config_env.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{env_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{env_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_label.html
+++ b/templates/config_label.html
@@ -21,7 +21,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{label_conf.id}}.yaml"
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{label_conf.id}}.yaml"
                 class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>

--- a/templates/config_repo.html
+++ b/templates/config_repo.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{repo_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_unwanted.html
+++ b/templates/config_unwanted.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{unwanted_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{unwanted_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_view.html
+++ b/templates/config_view.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{view_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{view_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/config_workload.html
+++ b/templates/config_workload.html
@@ -20,7 +20,7 @@
 
     <div class="card">
         <h5 class="card-header">
-            <a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{workload_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
+            <a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{workload_conf.id}}.yaml" class="btn btn-sm btn-primary float-right">Edit Configuration</a>
             Configuration
         </h5>
         <div class="card-body">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -10,22 +10,6 @@
         <a class="btn btn-primary btn-lg" href="./workloads.html" role="button">Explore results</a>
     </div>
 </div>
-<div class="jumbotron jumbotron-fluid jumbotron-about">
-    <div class="container">
-        <div class="row ">
-            <div class="col-sm-12">
-                <h3>Fedora Minimization Objective</h3>
-                <p class="lead">
-                    Minimization is a key goal of <a href="https://getfedora.org/">Fedora</a> focusing on installation
-                    footprint of popular workloads in the Fedora ecosystem to make them more suitable
-                    for modern deployments such as IoT and cloud.
-                </p>
-                <a class="btn btn-secondary" href="https://docs.fedoraproject.org/en-US/minimization/">Fedora
-                    Minimization Docs</a>
-            </div>
-        </div>
-    </div>
-</div>
 
 <div class="jumbotron jumbotron-feature">
     <div class="container">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -105,14 +105,13 @@
             </ul>
           </div>
           <div class="col-6 col-md">
-            <h5>Fedora Minimization</h5>
+            <h5>Fedora ELN</h5>
             <ul class="list-unstyled text-small">
               <li>
-                <a class="text-muted" href="https://docs.fedoraproject.org/en-US/minimization/">Fedora Minimization
-                  Docs</a>
+                <a class="text-muted" href="https://docs.fedoraproject.org/en-US/eln/">Fedora ELN Docs</a>
               </li>
               <li>
-                <a class="text-muted" href="https://pagure.io/minimization/issues">Minimization Tracker</a>
+                <a class="text-muted" href="https://github.com/fedora-eln/eln/issues">Issue Tracker</a>
               </li>
             </ul>
           </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -134,7 +134,7 @@
             <small class="d-block mb-3 text-muted">Fedora is sponsored by Red Hat. <a
                 href="https://www.redhat.com/en/technologies/linux-platforms/articles/relationship-between-fedora-and-rhel">Learn
                 more about the relationship between Red Hat and Fedora »</a></small>
-            <small class="d-block mb-3 text-muted">Copyright © 2020 Red Hat, Inc.</small>
+            <small class="d-block mb-3 text-muted">Copyright © 2026 Red Hat, Inc.</small>
           </div>
         </div>
       </footer>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -97,10 +97,10 @@
             <h5>Content Resolver</h5>
             <ul class="list-unstyled text-small">
               <li>
-                <a class="text-muted" href="https://github.com/minimization/content-resolver">Code repository</a>
+                <a class="text-muted" href="https://github.com/fedora-eln/content-resolver">Code repository</a>
               </li>
               <li>
-                <a class="text-muted" href="https://github.com/minimization/content-resolver-input">Configuration</a>
+                <a class="text-muted" href="https://github.com/fedora-eln/content-resolver-input">Configuration</a>
               </li>
             </ul>
           </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -120,10 +120,10 @@
             <h5>Fedora Project</h5>
             <ul class="list-unstyled text-small">
               <li>
-                <a class="text-muted" href="https://fedoraproject.org/wiki/Overview">About Fedora</a>
+                <a class="text-muted" href="https://docs.fedoraproject.org/en-US/project/">About Fedora</a>
               </li>
               <li>
-                <a class="text-muted" href="https://getfedora.org/">Get Fedora</a>
+                <a class="text-muted" href="https://fedoraproject.org/">Get Fedora</a>
               </li>
             </ul>
           </div>

--- a/templates/repo-split.html
+++ b/templates/repo-split.html
@@ -120,7 +120,7 @@
                             <ul>
                             {% for repo_split_conf_id in repo_split_conf_ids %}
                             <li>
-                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
+                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
                             </li>
                             {% endfor %}
                             </ul>
@@ -135,7 +135,7 @@
                             <ul>
                             {% for repo_split_conf_id in repo_split_conf_ids %}
                             <li>
-                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/minimization/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
+                                {{query.configs.configs[repo_split_conf_id].maintainer}} <span class="text-muted">(<a href="https://github.com/fedora-eln/content-resolver-input/blob/main/configs/{{repo_split_conf_id}}.yaml">{{repo_split_conf_id}}.yaml</a>)</span>
                             </li>
                             {% endfor %}
                             </ul>


### PR DESCRIPTION
The CR code and input repos have both been moved, and we don't want to rely on Github's forwarding forever.